### PR TITLE
Release Kudzu 0.16.34: optional AI authoring tools

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,5 +1,52 @@
 # Performance Records
 
+## 0.16.34 Optional AI Authoring Tools
+
+User-authorized release transaction: core 0.16.34 and create-kudzu 0.1.156, through
+a reviewed PR, merge, exact-commit Linux CI, immutable tag and protected npm
+publication. Baseline is public 0.16.33 (`4c98059`); concurrent uncommitted compiler
+work in the other worktree is not included. No compiler or runtime source changes.
+
+The opt-in generator supplies a 1,828-byte AGENTS.md, a dependency-free Node tool,
+an npm command, and ignored logs. Document lookup returns installed README sections
+with source ranges and explicit truncation. Check execution retains the app's
+normal check script, failures, timeouts and full logs with a bounded output excerpt.
+This is a developer-time tool layer, not an agent replacement or browser runtime.
+
+### Measured and unmeasured results
+
+| Item | Result |
+|---|---|
+| Generated instructions | 1,828 UTF-8 bytes; 2 KiB regression ceiling |
+| Document section response | At most 6,000 text characters; full source path/range retained |
+| Check excerpt | At most first/last 2,048 log bytes plus an omission marker; full log retained |
+| Paired starter deploy | Four byte-identical files, 9,758 raw / 3,746 aggregate gzip B in each arm |
+| Additional deployed bytes | 0 for the tested default starter |
+| Generator package | Five files; no new dependency |
+| End-to-end AI-token savings | Unmeasured; no provider experiment ran |
+| Monetary savings | Unmeasured; response-byte limits are not token or dollar savings |
+
+The durable `test/create-kudzu-smoke.mjs` packages the generator and executes its
+generated doc/check tools against identical local core/TypeScript installations.
+Default and guided source are equivalent except developer files/scripts/ignore
+rules. It asserts the complete deployment file/byte comparison and static about
+route exclusion. Root files may still be published by custom deployment settings.
+The smoke is now part of `npm run test:package` and the existing CI/publication gate.
+
+The offline auditor independently reconciles 49 historical R2 usage streams with
+their archived normalized totals; one stream without usage remains incomplete.
+This validates accounting, not a current optimization. R16 raw evidence is still
+missing. Historical scores, public benchmark protocols, and AI/1.0 gates remain
+unchanged. See [harness research](docs/ai-harness-research.md) and the
+[R2 audit](docs/ai-harness-r2-audit.md) for provenance and limitations.
+
+Local release-candidate verification on macOS arm64, Node v25.6.1: focused tests
+6/6, `npm run check` (230 pages), core fresh packed-package smoke and paired
+generator smoke pass. Prior 0.16.30-based full runs and their failure/skip records
+remain in the research log; they are not relabeled as integrated-release tests.
+Exact PR and merged-commit Linux Node 22/24 checks must pass before tagging;
+their receipts belong to the corresponding GitHub checks and release.
+
 ## 0.16.33 Release Transaction
 
 The user authorizes verification, this session's reviewed commit/push, immutable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Kudzu compiles ordinary React-shaped TypeScript and TSX into complete static HTM
 
 > Experimental `0.16.x`: the compiler API and supported TSX surface may change.
 
-**Current release: [0.16.33](https://github.com/kudzujs/kudzu/releases/tag/v0.16.33).** Write reusable components, native event handlers, and pure collection expressions; Kudzu specializes supported source into static content and direct browser updates. Presentation-only conditional branches omit descendant lifecycle traversal when no owner in their runtime family needs it, removing a further 215 raw / 116 aggregate gzip JavaScript bytes from search. Stateful remounts and effect cleanup are preserved; measured search-transition medians remain approximately equal. AI-cost and 1.0 gates remain blocked.
+**Current release: [0.16.34](https://github.com/kudzujs/kudzu/releases/tag/v0.16.34).** Adds optional AI authoring instructions and local developer tools through `create-kudzu --ai`, preserving the 0.16.33 compiler and runtime. Document lookup and check execution provide bounded responses with full logs retained. AI-token savings are unmeasured; AI-cost and 1.0 gates remain blocked.
 
 - [Documentation](https://kudzujs.cloud/docs)
 - [Installation guide](https://kudzujs.cloud/docs#install)
@@ -35,6 +35,13 @@ npm run dev
 ```
 
 The generated project includes reusable components, an interactive state example, a zero-JavaScript static route, metadata, and responsive CSS.
+
+For optional AI authoring guidance and local developer tools, use
+`npm create kudzu@latest my-app -- --ai`. The generated `AGENTS.md` describes
+`npm run ai -- docs` for installed documentation and `npm run ai -- check` for
+typecheck/build execution with bounded output and full retained logs. These tools
+stay outside default browser output. AI-token savings have not been measured.
+See the [generator guide](https://github.com/kudzujs/kudzu/tree/main/packages/create-kudzu#optional-ai-authoring-guidance).
 
 To add Kudzu to an existing project:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,27 @@
 # Kudzu Releases
 
+## 0.16.34 - Optional AI Authoring Tools
+
+- Publishes `create-kudzu@0.1.156` with opt-in `--ai`: app-root instructions,
+  a dependency-free Node developer tool, an `ai` npm script, and ignored local logs.
+- Provides installed-version README section lookup and real typecheck/build
+  execution. Check results retain failure codes, timeouts, and complete logs while
+  bounding the excerpt returned to an agent. They do not certify browser behavior.
+- Keeps generated app source and dependencies equivalent apart from the development
+  entry point; paired packaged-generator smoke checks byte-identical deploy output
+  and static zero-JavaScript output. No compiler/runtime implementation changes.
+- Adds a read-only historical trace auditor. R2 accounting matches 49 archived
+  usage traces; one missing-usage stream remains incomplete. This is tooling
+  validation, not a new model experiment or a substitute for missing R16 evidence.
+- **AI-token and monetary savings are unmeasured.** Instructions and tool calls
+  also consume context. No percentage reduction or cleared AI-delivery gate is claimed.
+- Exact-commit Linux CI and protected npm publication are release gates. The
+  generator produces apps targeting `@kudzujs/core@^0.16.34`.
+
+```sh
+npm create kudzu@latest my-app -- --ai
+```
+
 ## 0.16.33 - Conditional DOM Mount Exclusion
 
 - Projects existing `condition.mount` metadata across each runtime family, excluding

--- a/docs/ai-harness-r2-audit.md
+++ b/docs/ai-harness-r2-audit.md
@@ -1,0 +1,127 @@
+# Historical R2 trace audit
+
+2026-09-12, offline. This verifies an investigation tool against available old
+records; it is not a new AI trial, a current framework comparison, or R16 recovery.
+
+## Provenance
+
+GitHub Actions listed zero artifacts. The repository release assets exposed the
+older [v0.16.19 evidence archive](https://github.com/kudzujs/kudzu/releases/download/v0.16.19/kudzu-ai-delivery-0.21.4-gpt-5.6-sol.tar.gz).
+The downloaded 7,615,233-byte archive matches both GitHub's asset digest and the
+recorded PERFORMANCE digest:
+
+`4e37d15b4c4b0cf88720a3a7743996794b2e0172dbc43d40514f944fb01bd0f8`
+
+It contains 100 `adapter.stdout` streams across the invalid original batch and
+revision 2. Only the 50 streams below were audited:
+
+`test-results/ai-delivery-production/0.21.4-gpt-5.6-sol-r2/*/attempts/*/adapter.stdout`
+
+The original batch is retained and not combined with R2. These are older inputs
+(the inspected Content starter pins core 0.16.18), not the 0.16.30 worktree or R16.
+R16's named archive was not found in the previously searched Documents/Downloads/
+temporary paths, additional OpenCode data/cache searches, or these GitHub assets.
+Its original owner must still provide a location for the current investigation.
+
+## Read-only analyzer
+
+`test/ai-harness-audit.mjs` reads OpenCode JSON event streams without executing their
+commands. It reports:
+
+- Source SHA-256, stream lines, message IDs, errors, missing usage, and unfinished
+  messages. Non-JSON installation preamble lines are identified separately.
+- Uncached input, cache reads/writes, output, reasoning, and the existing adapter's
+  historical normalized total. These are not a new billing interpretation.
+- A first-build command candidate and whole-message phase totals. Detection is a
+  limited shell-text heuristic, not execution tracing; review the command before
+  interpreting phase totals. Aliases/wrappers and complex shell syntax may be missed.
+- Recorded tool output bytes, truncation flags, and exact read/glob/grep/list
+  request-plus-output repeats. Different ranges, changed outputs, failed reads,
+  and explicitly truncated output are not counted as exact repeat candidates.
+- An intervening-potential-mutation flag for repeats separated by shell commands,
+  edits, or other potentially side-effecting tools. Even without that flag, an
+  exact recorded repeat is not a safe live cache hit or permission to skip a read.
+
+Metadata/preview duplication is excluded from response-byte counts; the transcript
+alone does not establish every byte actually supplied to the model. Model-step
+tokens are never allocated to individual calls. A terminal stop is not acceptance,
+and an audited stream is not proof of complete provider billing.
+
+```sh
+node --test test/ai-harness-audit.test.mjs
+
+# EVIDENCE is the extracted archive directory. Choose a new report path each time.
+node test/ai-harness-audit.mjs --details --out /absolute/new-r2-audit.json \
+  "$EVIDENCE"/test-results/ai-delivery-production/0.21.4-gpt-5.6-sol-r2/*/attempts/*/adapter.stdout
+```
+
+The R2 command intentionally exits 1 after writing a partial report: one stream
+has no usage. It retains that file as `status: invalid`, not a zero-token success.
+Malformed streams are also explicit invalid entries. Existing report files are
+never overwritten (`wx`). Omit `--details` to exclude the complete tool/step ledger.
+No model call, network request, or archived command execution occurs in the analyzer.
+
+## Offline results
+
+All 50 R2 paths remain in the report. The 49 usage-bearing streams match their
+archived `adapter.trace.jsonl` exactly for normalized input, output, and reasoning.
+`realtime-react-vite-3` has no recorded model usage; total cost attribution therefore
+remains incomplete. No success status or historical denominator was changed.
+
+| Task | Kudzu usage-bearing streams | React usage-bearing streams | Kudzu tokens before first build candidate | React tokens before first build candidate |
+|---|---:|---:|---:|---:|
+| Content | 5 | 5 | 613,623 | 270,192 |
+| Forms | 5 | 5 | 239,066 | 349,434 |
+| CRUD | 5 | 5 | 438,170 | 340,113 |
+| Commerce | 5 | 5 | 229,542 | 159,038 |
+| Realtime | 5 | 4 | 432,205 | 324,385 |
+
+These are historical scheduled usage, not success-normalized costs. In particular,
+the incomplete Realtime column is not a fair five-attempt comparison. Whole-message
+phase boundaries can include several tools and must not be treated as precise
+per-command cost attribution.
+
+No exact request-plus-output repeat candidates were found across the 49 streams
+under the analyzer's conservative non-truncated read-tool definition. This does
+not exclude overlapping ranges, semantically repeated searches, shell-based reads,
+or repeated information across different requests.
+
+Kudzu Content has six pre-build package `read` calls returning 57,164 recorded
+output bytes; React Content has none. Searches and shell reads are not in that
+count. One inspected source, `content/attempts/content-kudzu-0/adapter.stdout`, shows:
+
+- Lines 26–27: package enumeration and `useState` search exposing internal docs.
+- Line 30: a range of the public README.
+- Lines 33–34: event/collection searches returning internal framework/evidence text.
+
+Internal documentation was subsequently excluded from the published package in
+later work, as the existing R8 record explains. Do not implement that fix again
+or extrapolate this old path to R16's current bottleneck.
+
+**Decision:** no new live read cache, mandatory inventory policy, or automatic
+generator instructions are justified by this audit. The concrete deliverable is
+the reusable offline audit tool, ready for the missing R16 streams. It allows
+candidate selection from recorded requests rather than from aggregate guesses.
+
+## Validation and local outputs
+
+- Focused analyzer checks: 2/2 passed. They cover usage categories, mixed/duplicate
+  messages, malformed JSON, incomplete streams, mutation/range/truncation boundaries,
+  UTF-8 byte counts, missing usage, input preservation, and report overwrite refusal.
+- `npm run check`: passed; 230 pages, two interactive.
+- `CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm test`:
+  standalone 1/1 plus main suite 326 passed, five Linux-only browser-smoke tests
+  skipped, zero failures. This is not a zero-skip Linux release gate.
+- This change does not alter installed package files, compiler/runtime behavior,
+  generator output, benchmark inputs, or the other session's seven modified files.
+
+Local external evidence is under the approved temporary workspace:
+
+- `kudzu-historical-ai-evidence/`: extracted original archive.
+- `kudzu-r2-audit.json`: 50-path detailed report, explicitly incomplete.
+- `summarize-kudzu-r2-audit.mjs`: one-off reconciliation against archived normalized
+  traces and table aggregation. Raw archive remains unchanged.
+
+Temporary paths are not durable published evidence. The release URL/digest and
+the checked-in analyzer permit reconstruction; R16 recovery is still required
+before selecting its first evidence-backed live harness intervention.

--- a/docs/ai-harness-research.md
+++ b/docs/ai-harness-research.md
@@ -1,0 +1,283 @@
+# AI authoring harness: cost research
+
+Status: offline investigation, 2026-09-12. No model experiment or measured saving.
+Base: `f1ef2b0aac3c8d714ae9f7965b2008bfed84e38d` (Kudzu 0.16.30).
+Workspace: `kudzu-ai-tooling`, branch `feat/ai-authoring-support`.
+
+Release follow-up: the user subsequently authorizes commit/push, PR/merge, tag and
+release. The integrated candidate is core 0.16.34 / generator 0.1.156 on public
+0.16.33 (`4c98059`), preserving the original investigation results below. Current
+release verification is recorded in PERFORMANCE; no AI saving is asserted.
+
+Follow-up: [historical R2 trace audit](ai-harness-r2-audit.md) recovers the public
+older archive and validates a read-only analysis CLI against 49 recorded usage
+streams, retaining one missing-usage stream. It does not replace the missing R16
+evidence or establish a live harness optimization.
+
+## Responsibility and boundary
+
+Reduce the complete AI cost of delivering a working Kudzu application, including
+failed attempts, without reducing behavior, accessibility, source maintainability,
+or verification. The other session owns compiler/runtime correctness and framework
+performance, including its seven-file 0.16.31 metadata/evidence patch.
+
+This track owns developer-time context delivery, tool ergonomics, observations,
+and avoidable discovery/repair loops. Coordinate edits to the generator, shared
+CLI, diagnostics, browser helpers, and benchmark infrastructure before integration.
+Run installations/builds in this worktree; source isolation does not isolate shared
+ports, processes, global configuration, or provider quotas.
+
+This is a maintainer research record, not app instructions or benchmark public
+context. Do not expose historical failures, grader internals, or task solutions to
+the measured agent. No compiler change, generator change, agent plugin, version
+bump, historical protocol edit, or provider call was part of the initial research
+packet. The subsequently requested opt-in generator prototype is recorded below.
+
+## What the existing evidence says
+
+These are recorded results, not newly recovered or independently replayed traces.
+See [Performance Records](../PERFORMANCE.md) and the named sections in the
+[application capability plan](next-architecture/application-capability-release-plan.md).
+
+| Record | Observation | Consequence for this track |
+|---|---|---|
+| `0.20.5 Tooling Cost Validation` | Plain build and structured build/inspect/explain both passed 5/5. Tokens/success were 67,860 versus 84,793, about 24.95% higher with the tool bundle. | Do not make every task call inspect/explain; tool availability is not a saving. |
+| `Focused 0.16.27 Content R9 Result` | All five Kudzu agents read verification guidance, but none followed the URL or performed an agent-owned browser journey. | More documentation alone does not establish adoption. |
+| `CONTENT R13 Measurement And Map Removal` | Installed-package map exposure was 1/5, with no observed map-directed navigation; cost objective remained unmet. | Do not reintroduce the removed map as a proven fix. |
+| `CONTENT R14 Symmetric Inventory Policy` | Kudzu 1/5 and React 2/5 within budgets, although all final acceptance checks passed. Extra reads outweighed smaller inventory output. | Reject mandatory full-project discovery and byte-only success criteria. |
+| `Offline Non-Adjacent Observation Reuse` | Lossless expanded records reduced serialized output by 10.61% in the recorded projection. | Reuse the existing helper; response bytes are not measured end-to-end tokens. |
+| `CONTENT R16: Explicit Role Selection` | Kudzu 5/5, React 4/5; Kudzu cost/success remained 14.15% higher. Optional unique-role targeting adoption was 0/10. | A capability must be discoverable and used before it can explain a saving. Do not silently weaken exact-name checks. |
+| `Default AX Summary Deduplication` | Two offline replays reduced response bytes by about 51%, retaining documented observation/action checks. | Already implemented; no new compression layer is justified by this result alone. |
+| `CONTENT R17 Three-Way Measurement` | Original scorer incorrectly counted hidden cards. Unchanged-artifact replay passed 15/15. | Preserve original scores; a replay is not a new model trial or fair three-way cost ranking. |
+
+### Selected question: work before the first build
+
+R16's recorded scheduled totals decompose as follows:
+
+| Phase | Kudzu | React | Difference | Share of difference |
+|---|---:|---:|---:|---:|
+| Before first build | 669,707 | 421,909 | 247,798 | 51.90% |
+| First-build message | 117,004 | 93,689 | 23,315 | 4.88% |
+| After first build | 809,348 | 602,976 | 206,372 | 43.22% |
+| Total | 1,596,059 | 1,118,574 | 477,485 | 100.00% |
+
+The phase gap is not a success-normalized cost decomposition: there were five
+Kudzu successes and four React successes. It also does not mean that 51.90% is
+waste or recoverable. Pre-build work includes necessary reading, implementation,
+model reasoning, and repeated context processing, not just source discovery.
+
+Cache-read input is 1,320,448 of Kudzu's 1,596,059 recorded tokens (82.73%). Fewer
+response bytes cannot predict cache usage, additional model steps, or dollar cost.
+Shorter prompts can also change cache behavior; measure categories separately.
+
+## Existing infrastructure to reuse
+
+- `bin/kudzu.mjs`: build JSON diagnostics, inspect, and exact-route explain already
+  exist. Inspect/explain rebuild; they are not free reads of an existing report.
+- `test/browser-smoke.mjs` and `test/browser-smoke-public.md`: existing bounded
+  browser observations, exact/unique-role selection, and observation reuse. The
+  current utility explicitly requires Linux Chrome; this workstation is macOS.
+- `test/ai-delivery-runner.mjs`: frozen inputs, isolated starters, independent
+  acceptance, retained failures, and baseline/tool-assisted summaries. Reuse for
+  a new protocol after reviewing current metric and lifecycle limitations.
+- `test/ai-delivery-opencode-adapter.mjs`: captures raw OpenCode events and invokes
+  `opencode run --pure --auto`. Do not assume the interactive session's Ponytail
+  hooks or future generated AGENTS.md are used in this execution mode. Verify
+  actual context delivery before measuring it.
+- `test/fixtures/ai-tooling-cost/bootstrap/`: an existing same-framework tooling
+  comparison, not a replacement for representative app-delivery tasks.
+
+## Ranked hypotheses, not approved implementations
+
+1. **Remove a proven redundant discovery round trip.** Recover the first-build
+   traces and identify repeated unchanged paths/ranges or package-location probes.
+   Only then choose the smallest existing-tool or context-delivery correction.
+   Necessary import/config/asset exploration must remain possible. Do not impose
+   a global inventory, dependency-read ban, forced first-build deadline, or hidden
+   source restriction.
+2. **Improve delivery of one needed instruction.** If traces show a specific
+   public instruction was needed but not found, compare its existing delivery with
+   one concise, version-matched entry point. Count instruction tokens and verify
+   exposure, use, and resulting reads. Generated app AGENTS.md is a candidate,
+   not the predetermined solution; do not copy compiler-maintainer rules into apps.
+3. **Reuse equivalent verification observations.** Keep the existing compaction.
+   Add behavior only if replay proves a remaining duplication with a trustworthy
+   freshness boundary. Preserve every error, action, assertion, and recovery path;
+   changed source or DOM cannot reuse stale evidence. Do not skip rechecks after edits.
+
+Defer multi-agent orchestration, persistent cross-task memory, additional model
+calls, and a new MCP/plugin service until a concrete task requires them. These add
+cost and experimental variables before the present bottleneck is understood.
+
+## Next offline packet and missing evidence
+
+Required archive: `role-only-r16-20260911-audited.tar.gz`.
+Recorded SHA-256:
+`c8dbd8880124c9a64ca2b437a62300bd608ff08767778897eba7ad1cee1495ad`.
+
+The archive was not found by exact-name searches under Documents, Downloads, or
+the approved temporary workspace. Raw R16 files were not found in this worktree.
+This is a scoped search, not proof that the archive does not exist elsewhere.
+
+1. Obtain the archive location from its owner; verify the digest and extract into
+   a separate evidence directory while retaining original bytes and manifests.
+2. Review all ten attempts through the first model build. Keep source stream/line,
+   command or read range, output completeness, changed-file state, and model-step
+   association for each candidate redundancy. Report unknowns rather than guessing.
+3. Separate useful discovery, repeated inventories/reads, implementation, tool
+   failures, and first-build work. A repeated path with changed contents or a new
+   range is not automatically redundant. Do not apportion a step's usage to its
+   individual tool calls without attributable data.
+4. Replay one demonstrated correction offline, retaining failure behavior and
+   complete observations. Report bytes/operations separately from unmeasured tokens.
+5. If nothing actionable is established, close the packet without a product change.
+
+## Model experiment design, only after separate approval
+
+First compare **Kudzu + baseline harness** with **the same Kudzu + one harness
+change**. Hold package integrity, model/reasoning settings, starter, task, browser
+environment, budgets, scorer, and all unrelated instructions/tools constant.
+Do not compare a newly optimized Kudzu version with an old React run to attribute
+a harness gain. Ponytail settings are either equal in both arms or the sole named
+intervention, never silently added together with another change.
+
+Use a separately named frozen protocol and a predeclared interleaved schedule.
+Pilot proposal: one task, five attempts per arm, with no selective retries. This is
+screening evidence, not a general superiority claim. After a promising pilot,
+validate on held-out task classes before considering default generator integration.
+
+If comparing frameworks later, use the same selected generic harness and equal
+tool opportunities for Kudzu and React; provide each framework's ordinary public
+documentation under the same policy. Keep this comparison separate from the
+same-framework ablation and preserve all historical results.
+
+Before provider calls, freeze actual context-delivery behavior and hashes, validate
+the corrected visibility acceptance including negative controls, and run the
+existing lifecycle/protocol/browser/copy-integrity gates in the supported environment.
+Report expected usage and the spending/stop policy for approval; existing input
+budgets are graded after execution and are not a hard provider billing cap.
+
+## Acceptance and accounting
+
+Primary metric: sum of all scheduled attempt tokens, including failures, divided
+by independently accepted, within-budget successes. No successes means undefined
+cost/success, not zero. Incomplete traces mean incomplete cost attribution. Retain
+availability probes, interruptions, and auxiliary model calls as separate overhead
+and report the complete experiment total as well as the scheduled metric.
+
+Record uncached input, cache-read/write input, output, reasoning, model steps,
+wall time, tool failures, builds, correction cycles, and framework artifact metrics.
+Verify provider usage semantics before summing categories: reasoning may be included
+in output for some APIs. Preserve the historical normalization, and explicitly
+version any new accounting correction rather than rewriting old scores. The current
+normalized trace folds cache-read input into input; detailed cache accounting needs
+the raw events. Zero subscription-reported dollars do not establish free work.
+Dollar claims require actual billing or an explicit dated rate model with cache
+and reasoning semantics, not an undisclosed conversion from total tokens.
+
+Require behavior, accessibility checks, source maintainability, and applicable
+static-route/output contracts in both arms. Do not promote a lower-cost pilot with
+lower observed success or weaker verification. Inspect ranges and every failure;
+five pairs cannot establish statistical non-inferiority or universal savings.
+Offline byte reductions and tool adoption are diagnostic metrics, not acceptance
+of the AI-cost objective. A positive pilot requires a separately approved replication.
+
+## User-requested opt-in context delivery prototype
+
+The subsequent request explicitly asks how an app's coding agent can discover
+Kudzu guidance, including installation through create-kudzu. The local generator
+now accepts `--ai`, creating one app-root `AGENTS.md` and a README link. This is an
+opt-in delivery mechanism, not a trace-proven fix, default policy, or full agent
+runtime. R16 recovery and actual token-cost measurement remain outstanding.
+
+The generated file is 1,638 UTF-8 bytes with a tested 2 KiB ceiling. It identifies
+app conventions, local installed-version docs/types, and build/browser verification
+requirements. It does not prescribe a full inventory or require inspect/explain.
+No extra model, dependency, plugin, global configuration, or browser capability is
+installed. The generator's existing nonempty-target check protects existing files.
+
+The [OpenCode rules documentation](https://opencode.ai/docs/rules/) and
+[Codex instructions documentation](https://developers.openai.com/codex/agent-configuration/agents-md)
+describe root AGENTS.md discovery. Launch a new supporting agent session from the
+generated app root. Merely placing instructions in compiler source or node_modules
+does not make them auto-loaded. This session did not run a model to validate actual
+prompt inclusion, adoption, or savings. Agent settings, overrides, context limits,
+and benchmark execution modes must be checked in the eventual experiment.
+
+Implementation: `packages/create-kudzu/index.mjs`, package README, and
+`test/create-kudzu.test.mjs`. No core version or historical protocol changes.
+Local usage and post-release npm syntax are in the
+[generator README](../packages/create-kudzu/README.md#optional-ai-authoring-guidance).
+
+Validation:
+
+- New generator regression failed before implementation and passes afterward;
+  generator tests 2/2. Default starter has no AGENTS.md; opt-in changes only that
+  file and the README. App source, manifests, and configuration are byte-identical.
+- Packed generator contains four files and successfully generates both variants.
+  Both typecheck and build against the same local core/TypeScript via temporary
+  symlinks. All four deploy files match byte-for-byte (9,758 bytes total);
+  AGENTS.md/README are absent, and the static about route has no script/preload.
+  This proves the default starter output boundary, not custom deployment rules.
+  The local reproduction is `kudzu-ai-generator-smoke.mjs` in the approved temporary
+  workspace; it uses no provider calls and removes its generated projects.
+- `npm run check` passes: 230 pages, two interactive.
+- Full macOS Chrome test run: standalone 1/1; main suite 326 passed, one existing
+  Apache Answer route-shell Chrome spawn timeout, five Linux-only tests skipped.
+  The unchanged failing test passes its isolated rerun (1/1). The first failure
+  remains recorded; this is not a clean full-suite or Linux release-gate claim.
+- Tracked diff whitespace validation passes. No model experiment, commit,
+  publication, or assertion of lower AI cost follows the scaffold implementation.
+
+## Executable developer-tool follow-up
+
+The next user request authorizes connecting actual harness tools through the
+generator. This supersedes the instruction-only delivery scope above. It remains
+opt-in and does not require a new repository, published dependency, MCP setup, or
+global host configuration. The generator copies `ai.mjs` to the app's
+`kudzu-ai.mjs`, adds an `ai` npm script, and ignores `.kudzu-ai/` logs.
+
+The generated tools provide:
+
+- `npm run ai -- docs [heading]`: versioned, local README section lookup, ignoring
+  headings inside fenced code. Index-only output by default; selected sections
+  carry original line ranges and explicit truncation at 6,000 characters.
+- `npm run ai -- check`: executes the existing npm check script, reports real
+  exit/failure/timeout state, and preserves full stdout/stderr in a unique log.
+  Output excerpts are bounded to the first/last 2,048 bytes when necessary. An
+  error in the omitted middle remains in the original log; the JSON exposes its
+  path and truncation. The tool never marks browser verification complete.
+- Five-minute default timeout, configurable up to twenty minutes; Unix process
+  group or Windows task-tree termination on timeout/interruption. Recursive check
+  invocation is rejected. No caching or stale-result reuse is implemented.
+
+The entry-point regression exposed macOS `/var` versus `/private/var` identity:
+lexical path comparison silently skipped the copied CLI. Realpath comparison fixes
+entry execution and recursive-check detection. Focused tests verify nonzero CLI
+exits from an unrelated cwd, exact log preservation, missing document
+sections, truncated responses, successful checks, timeout child termination, and
+recursive-call rejection. No model or browser runs are needed for those tests.
+
+Final validation on this 0.16.30-based worktree:
+
+- Focused generator/tool tests: 4/4 passed.
+- Packed generator: five files, including `ai.mjs`; no new dependency.
+- Generated guidance: 1,828 UTF-8 bytes, within its 2 KiB ceiling.
+- Packed-generator smoke: local Authoring lookup reports core 0.16.30; actual
+  `npm run --silent ai -- check` typechecks and builds successfully. Baseline and
+  guided starters still produce four byte-identical deployment files, 9,758 B.
+  The generated helper, instructions, and logs are outside default deployment.
+- `npm run check`: passed, 230 pages, two interactive.
+- macOS Chrome `npm test`: standalone 1/1; main suite 329 passed, five Linux-only
+  skips, zero failures. This does not replace the earlier recorded timeout or
+  certify Windows behavior or a zero-skip Linux release gate.
+
+The other worktree was left unchanged. Its observed HEAD advanced to release
+0.16.33; that does not update this isolated prototype's tested baseline. Test and
+benchmark process probes were empty before the sequential full verification;
+worktrees still share machine resources and future timing runs need coordination.
+
+This is a working developer-tool layer for an agent's existing shell tool, not a
+replacement for OpenCode/Codex and not proof of token savings. Actual adoption and
+same-framework cost ablation remain outstanding. Generated files are snapshots;
+existing projects merge changes explicitly instead of overwriting their setup.

--- a/docs/next-architecture/versioning.md
+++ b/docs/next-architecture/versioning.md
@@ -66,11 +66,18 @@ Keep each patch behavior-preserving and independently reviewable. If a boundary 
 
 ## Generator Versions
 
-`create-kudzu@0.1.155` retains the explicit install instructions and generates projects with `@kudzujs/core@^0.16.30`.
+`create-kudzu@0.1.156` retains the explicit install instructions, adds opt-in `--ai`
+developer tools, and generates projects with `@kudzujs/core@^0.16.34`.
 
 ## Release Boundary
 
-The active user-authorized release transaction is `0.16.33`, conditional DOM mount exclusion
+The active user-authorized transaction is core `0.16.34` and generator `0.1.156`,
+optional AI authoring tools. It integrates the public 0.16.33 baseline without the
+other worktree's subsequent compiler changes. The user requests commit, push, PR,
+merge, immutable tag, and release. Follow normal protected npm publication after
+exact-commit Linux CI; do not report AI-cost savings without a model experiment.
+
+The previous user-authorized release transaction was `0.16.33`, conditional DOM mount exclusion
 using existing route facts. `0.16.32` completed its tag, CI, GitHub/npm publication
 and fresh-install verification before this packet began. No generator change is
 needed; the existing `^0.16.30` range remains compatible. Exact-commit Linux CI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kudzujs/core",
-  "version": "0.16.33",
+  "version": "0.16.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kudzujs/core",
-      "version": "0.16.33",
+      "version": "0.16.34",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kudzujs/core",
-  "version": "0.16.33",
+  "version": "0.16.34",
   "description": "HTML-first TSX framework with synchronous state semantics and no virtual DOM",
   "type": "module",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "check": "tsc --noEmit && tsc -p test/fixtures/tsconfig.json --noEmit && node ./bin/kudzu.mjs build",
     "test": "node --test test/project-application.test.mjs && node --test --test-skip-pattern='^establishes the 0\\.17\\.0 notification WebSocket ownership contract$' test/*.test.mjs",
     "test:endurance": "node test/endurance.mjs",
-    "test:package": "node test/package-smoke.mjs",
+    "test:package": "node test/package-smoke.mjs && node test/create-kudzu-smoke.mjs",
     "benchmark": "node test/performance.mjs",
     "benchmark:keyed": "node test/keyed-performance.mjs",
     "benchmark:commerce": "node test/commerce-build-performance.mjs",

--- a/packages/create-kudzu/README.md
+++ b/packages/create-kudzu/README.md
@@ -10,6 +10,77 @@ cd my-app
 npm run dev
 ```
 
-The generated project is a working showcase on `@kudzujs/core@^0.16.30` with reusable components, an interactive state example, a zero-JavaScript static route, page metadata, responsive source CSS, and `npm run check`. Configuration remains optional until the app needs custom assets, document defaults, navigation, or build hooks.
+The generated project is a working showcase on `@kudzujs/core@^0.16.34` with reusable components, an interactive state example, a zero-JavaScript static route, page metadata, responsive CSS, and `npm run check`. Configuration remains optional until the app needs custom assets, document defaults, navigation, or build hooks.
 
 Use `--no-install` to create the files without installing dependencies.
+
+## Optional AI authoring guidance
+
+`create-kudzu@0.1.156` adds optional local AI developer tools:
+
+```bash
+npm create kudzu@latest my-app -- --ai
+```
+
+From a source checkout:
+
+```bash
+node /path/to/kudzu/packages/create-kudzu/index.mjs my-app --ai
+```
+
+This adds a short `AGENTS.md`, a standard-library-only `kudzu-ai.mjs` developer
+tool, and an `ai` npm script. Check logs are ignored through `.kudzu-ai/`.
+Combine with `--no-install` to generate files without installing packages.
+Without `--ai`, the starter stays unchanged.
+
+### Developer tools
+
+```bash
+npm run ai -- docs
+npm run ai -- docs Authoring
+npm run ai -- check
+npm run ai -- check --timeout-ms 600000
+```
+
+- `docs` lists level-two headings from the installed core README, including the
+  installed version and file path. Supply one exact, case-insensitive heading
+  (quote multi-word headings) to return that section. Sections are capped at
+  6,000 characters with explicit truncation and original line ranges. Follow the
+  file reference if more is needed. This uses the generated npm dependency layout;
+  install dependencies before reading docs. It makes no network or model calls.
+- `check` executes the app's existing `npm run check`, including its npm lifecycle
+  hooks, from the project root. It returns JSON status, exit code, timing and a
+  log excerpt. Failure stays nonzero. The default timeout is five minutes; choose
+  an integer from 1 to 1,200,000 ms. Timeout/cancellation terminates the spawned
+  process group on Unix or process tree on Windows and reports failure.
+- Full stdout/stderr are retained in a unique `.kudzu-ai/check-*/output.log`.
+  Large logs show the first/last 2,048 bytes with an omission marker; an error may
+  be in the omitted middle. Read the full log when needed. Old logs are not deleted
+  automatically; remove `.kudzu-ai/` when no longer needed.
+- The tool does not cache checks or certify browser behavior. Later edits require
+  a new check. Scripts that intentionally detach background jobs or custom
+  deployment rules need their own lifecycle/asset handling. Use
+  `npm run --silent ai -- check` to suppress npm's outer lifecycle banner.
+
+Start a new [OpenCode](https://opencode.ai/docs/rules/) or
+[Codex](https://developers.openai.com/codex/agent-configuration/agents-md) session
+from the app root to use their documented project-instruction discovery. Other
+agents need support for `AGENTS.md` or an explicit request to read it. Editor
+installation alone does not load instructions. Overrides, disabled discovery,
+context limits, and headless modes can change loading; verify the effective
+instructions in the agent you actually use.
+
+AGENTS.md supplies guidance; kudzu-ai.mjs performs real document lookup and check
+execution. The host's existing shell tool can invoke it without an MCP connection
+or plugin. It does not intercept every agent action or force use of these commands.
+There is no additional dependency, agent installation, or model call for these
+tools. Both files stay outside `src` and `public` and are excluded by the default
+Kudzu build. Custom asset-copy/deployment settings can still publish root files.
+Instructions and tool responses add input context; lower total AI cost is unmeasured.
+
+For an existing app, generate a disposable `--ai --no-install` project, copy
+`kudzu-ai.mjs`, add `"ai": "node kudzu-ai.mjs"` to your scripts and `.kudzu-ai/` to
+your ignore rules, and merge the applicable instructions into your existing rules.
+Keep your real `check` script; do not make it invoke `ai check` recursively.
+The generator rejects nonempty targets. Generated tools/rules are snapshots, not
+auto-updated when Kudzu is upgraded; review them with your existing app setup.

--- a/packages/create-kudzu/ai.mjs
+++ b/packages/create-kudzu/ai.mjs
@@ -1,0 +1,112 @@
+import { spawn, spawnSync } from "node:child_process"
+import { mkdir, mkdtemp, open, readFile, realpath } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseArgs } from "node:util"
+
+export async function docs(root, heading) {
+  const directory = join(root, "node_modules/@kudzujs/core")
+  const { version } = JSON.parse(await readFile(join(directory, "package.json"), "utf8"))
+  const path = join(directory, "README.md")
+  const lines = (await readFile(path, "utf8")).split(/\r?\n/)
+  const sections = []
+  let fence
+  for (const [index, line] of lines.entries()) {
+    const delimiter = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/)
+    if (delimiter) {
+      if (!fence) fence = delimiter[1]
+      else if (delimiter[1][0] === fence[0] && delimiter[1].length >= fence.length && !delimiter[2].trim()) fence = undefined
+      continue
+    }
+    const title = !fence && line.match(/^##[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/)
+    if (title) sections.push({ heading: title[1], start: index })
+  }
+  const result = { version, path, headings: sections.map(section => section.heading) }
+  if (heading === undefined) return result
+  const matches = sections.filter(section => section.heading.toLowerCase() === heading.toLowerCase())
+  if (matches.length !== 1) throw new Error(`Expected one exact README heading. Available: ${result.headings.join(", ")}`)
+  const section = matches[0], end = sections[sections.indexOf(section) + 1]?.start ?? lines.length
+  const text = lines.slice(section.start, end).join("\n")
+  return { version, path, heading: section.heading, startLine: section.start + 1, endLine: end, text: text.slice(0, 6000), truncated: text.length > 6000 }
+}
+
+export async function check(root, timeoutMs = 300000) {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 1200000) throw new Error("timeout-ms must be an integer from 1 to 1200000")
+  root = await realpath(root)
+  if (process.env.KUDZU_AI_CHECK_ROOT === root) throw new Error("scripts.check must not invoke ai check recursively")
+  const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"))
+  if (typeof manifest.scripts?.check !== "string" || !manifest.scripts.check.trim()) throw new Error("package.json must define scripts.check")
+  const logs = join(root, ".kudzu-ai")
+  await mkdir(logs, { recursive: true })
+  const directory = await mkdtemp(join(logs, "check-")), path = join(directory, "output.log")
+  const log = await open(path, "wx+")
+  const start = performance.now()
+  try {
+    const result = await new Promise(resolveRun => {
+      const child = spawn(process.platform === "win32" ? "npm.cmd" : "npm", ["run", "check"], {
+        cwd: root, detached: process.platform !== "win32", shell: process.platform === "win32",
+        stdio: ["ignore", log.fd, log.fd], env: { ...process.env, FORCE_COLOR: "0", KUDZU_AI_CHECK_ROOT: root },
+      })
+      let timedOut = false, interrupted = null, error = null
+      const terminate = () => {
+        if (!child.pid) return
+        if (process.platform === "win32") {
+          const killed = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { encoding: "utf8" })
+          if (killed.status !== 0) error = killed.error?.message ?? killed.stderr ?? "Could not terminate check tree"
+        } else {
+          try { process.kill(-child.pid, "SIGKILL") } catch (failure) { if (failure.code !== "ESRCH") error = failure.message }
+        }
+      }
+      const onInterrupt = signal => { interrupted = signal; terminate() }
+      const onSigint = () => onInterrupt("SIGINT"), onSigterm = () => onInterrupt("SIGTERM")
+      process.once("SIGINT", onSigint)
+      process.once("SIGTERM", onSigterm)
+      const timer = setTimeout(() => { timedOut = true; terminate() }, timeoutMs)
+      child.once("error", failure => { error = failure.message })
+      child.once("close", (exitCode, signal) => {
+        clearTimeout(timer)
+        process.removeListener("SIGINT", onSigint)
+        process.removeListener("SIGTERM", onSigterm)
+        resolveRun({ exitCode, signal, timedOut, interrupted, error })
+      })
+    })
+    const { size } = await log.stat()
+    const buffer = Buffer.alloc(Math.min(size, 4096))
+    // ponytail: bounded head/tail is an excerpt, never a substitute for the retained full log.
+    let excerpt
+    if (size <= 4096) {
+      const { bytesRead } = await log.read(buffer, 0, buffer.length, 0)
+      excerpt = buffer.subarray(0, bytesRead).toString("utf8")
+    } else {
+      await log.read(buffer, 0, 2048, 0)
+      await log.read(buffer, 2048, 2048, size - 2048)
+      excerpt = buffer.subarray(0, 2048).toString("utf8") + "\n[... omitted; read full output.log ...]\n" + buffer.subarray(2048).toString("utf8")
+    }
+    return {
+      command: "npm run check", passed: result.exitCode === 0 && !result.timedOut && !result.interrupted && !result.error,
+      ...result, elapsedMs: Math.round(performance.now() - start),
+      log: { path, bytes: size, excerpt, truncated: size > 4096 },
+      browserVerified: false, note: "Fresh check result only; later edits invalidate it. Compiler success is not browser or accessibility proof.",
+    }
+  } finally {
+    await log.close()
+  }
+}
+
+if (process.argv[1] && await realpath(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const { positionals, values } = parseArgs({ allowPositionals: true, strict: true, options: { "timeout-ms": { type: "string" } } })
+    const root = dirname(fileURLToPath(import.meta.url)), [command, heading] = positionals
+    let result
+    if (command === "docs" && positionals.length <= 2 && values["timeout-ms"] === undefined) result = await docs(root, heading)
+    else if (command === "check" && positionals.length === 1) {
+      if (values["timeout-ms"] !== undefined && !/^\d+$/.test(values["timeout-ms"])) throw new Error("timeout-ms must be a decimal integer")
+      result = await check(root, values["timeout-ms"] === undefined ? undefined : Number(values["timeout-ms"]))
+      if (!result.passed) process.exitCode = result.exitCode || 1
+    } else throw new Error("Use: npm run ai -- docs [heading] | npm run ai -- check [--timeout-ms 300000]")
+    process.stdout.write(JSON.stringify(result) + "\n")
+  } catch (error) {
+    process.stderr.write(JSON.stringify({ error: error.message }) + "\n")
+    process.exitCode = 1
+  }
+}

--- a/packages/create-kudzu/index.mjs
+++ b/packages/create-kudzu/index.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process"
-import { mkdir, readdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises"
 import { basename, resolve } from "node:path"
 
 const args = process.argv.slice(2)
 const skipInstall = args.includes("--no-install")
+const ai = args.includes("--ai")
 const target = args.find(argument => !argument.startsWith("-")) ?? "kudzu-app"
 const root = resolve(target)
 
@@ -33,7 +34,7 @@ const files = {
       check: "tsc --noEmit && kudzu build"
     },
     dependencies: {
-      "@kudzujs/core": "^0.16.30"
+      "@kudzujs/core": "^0.16.34"
     },
     devDependencies: {
       typescript: "^5.9.2"
@@ -233,6 +234,31 @@ Documentation: https://kudzujs.cloud/docs
 `
 }
 
+if (ai) {
+  files["kudzu-ai.mjs"] = await readFile(new URL("./ai.mjs", import.meta.url), "utf8")
+  const manifest = JSON.parse(files["package.json"])
+  manifest.scripts.ai = "node kudzu-ai.mjs"
+  files["package.json"] = `${JSON.stringify(manifest, null, 2)}\n`
+  files[".gitignore"] += ".kudzu-ai/\n"
+  files["AGENTS.md"] = `# Kudzu application
+
+## Write
+- This is a Kudzu app, not the compiler repository. Routes are in src/pages; index.tsx maps to /. Reuse the existing components, data, and CSS relevant to the task.
+- Use ordinary function components and declarative TSX. Import hooks from @kudzujs/core. React-shaped syntax is compiler input, not full React runtime compatibility; do not add React, hydration, or a client router as a workaround.
+- Prefer native HTML controls, anchors, and events. Read input values through event.currentTarget.value inside the handler. State setters update logical state immediately; DOM writes are batched.
+
+## Find answers when needed
+- npm run ai -- docs lists installed-version README headings. npm run ai -- docs Authoring reads one section. Full local guide: node_modules/@kudzujs/core/README.md; public types: node_modules/@kudzujs/core/framework/core.d.ts. Read what the task needs.
+- Full guide and current limits: https://kudzujs.cloud/docs. Online docs can differ from the installed version; use local build diagnostics to confirm support.
+
+## Verify
+- npm run ai -- check runs npm run check (typecheck + build) with a timeout, JSON status, bounded excerpt, and full log in .kudzu-ai. Read that log if the excerpt is insufficient. This already performs the check; subsequent edits require a fresh check. npm run dev starts the dev server. Fix source, not generated output.
+- Build success does not prove browser behavior or accessibility. Exercise affected interactions in a browser and check labels, keyboard use, and visible results. Report unavailable checks instead of claiming a pass.
+- Static routes must remain JavaScript-free. Raw HTML text scans and compiler reports are not proof of visible DOM or complete script exclusion. Preserve required checks; avoid repeatedly dumping minified assets.
+`
+  files["README.md"] += "\nAI authoring guidance: [AGENTS.md](AGENTS.md). Start a supporting coding agent from this project root.\n\nRun `npm run ai -- docs` to list installed README headings, `npm run ai -- docs Authoring` to read a section, and `npm run ai -- check` to typecheck/build with a bounded result. Full check logs stay in `.kudzu-ai/`; remove that directory when no longer needed. Check results do not verify browser behavior.\n"
+}
+
 await Promise.all(Object.entries(files).map(async ([file, content]) => {
   await writeFile(resolve(root, file), content)
 }))
@@ -243,3 +269,4 @@ if (!skipInstall) {
 }
 
 console.log(`\nCreated ${name} in ${root}${skipInstall ? "" : " with dependencies installed"}\n\n  cd ${target}\n${skipInstall ? "  npm install\n" : ""}  npm run dev\n`)
+if (ai) console.log("AI authoring guidance: AGENTS.md. Start OpenCode or Codex from the project root in a new session.")

--- a/packages/create-kudzu/package-lock.json
+++ b/packages/create-kudzu/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-kudzu",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-kudzu",
-      "version": "0.1.155",
+      "version": "0.1.156",
       "license": "MIT",
       "bin": {
         "create-kudzu": "index.mjs"

--- a/packages/create-kudzu/package.json
+++ b/packages/create-kudzu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-kudzu",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "description": "Create a Kudzu project",
   "type": "module",
   "license": "MIT",
@@ -18,11 +18,12 @@
   },
   "files": [
     "index.mjs",
+    "ai.mjs",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test ../../test/create-kudzu.test.mjs",
+    "test": "node --test ../../test/create-kudzu.test.mjs ../../test/create-kudzu-ai.test.mjs",
     "prepublishOnly": "npm test"
   },
   "keywords": [

--- a/test/ai-harness-audit.mjs
+++ b/test/ai-harness-audit.mjs
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto"
+import { readFile, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { parseArgs } from "node:util"
+import { fileURLToPath } from "node:url"
+
+const hash = value => createHash("sha256").update(value).digest("hex")
+const readTools = new Set(["read", "glob", "grep", "list"])
+const usageKeys = ["input", "cacheRead", "cacheWrite", "output", "reasoning"]
+const emptyUsage = () => Object.fromEntries(usageKeys.map(key => [key, 0]))
+
+export function auditTrace(text) {
+  const steps = [], tools = [], ignoredLines = [], errors = []
+  const seenSteps = new Set(), started = new Set(), observations = new Map()
+  let sessionID, mutationEpoch = 0
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue
+    const lineNumber = index + 1
+    if (!line.trimStart().startsWith("{")) { ignoredLines.push(lineNumber); continue }
+    let event
+    try { event = JSON.parse(line) } catch { throw new Error(`Invalid JSON at line ${lineNumber}`) }
+    if (typeof event.type !== "string") throw new Error(`Missing event type at line ${lineNumber}`)
+    if (event.sessionID) {
+      if (sessionID && sessionID !== event.sessionID) throw new Error(`Mixed sessions at line ${lineNumber}`)
+      sessionID = event.sessionID
+    }
+    const part = event.part ?? {}, message = part.messageID
+    if (event.type === "error") errors.push(lineNumber)
+    if (event.type === "step_start") {
+      if (!message) throw new Error(`Missing step message at line ${lineNumber}`)
+      started.add(message)
+    }
+    if (event.type === "step_finish") {
+      if (!message || seenSteps.has(message)) throw new Error(`Missing or duplicate finished message at line ${lineNumber}`)
+      seenSteps.add(message)
+      const tokens = part.tokens
+      const usage = { input: tokens?.input, cacheRead: tokens?.cache?.read, cacheWrite: tokens?.cache?.write, output: tokens?.output, reasoning: tokens?.reasoning }
+      if (Object.values(usage).some(value => !Number.isSafeInteger(value) || value < 0)) throw new Error(`Invalid usage at line ${lineNumber}`)
+      steps.push({ line: lineNumber, message, reason: part.reason ?? null, usage })
+    }
+    if (event.type !== "tool_use") continue
+    const state = part.state
+    if (typeof part.tool !== "string" || !message || !state || typeof state.input !== "object" || state.input === null) throw new Error(`Invalid tool event at line ${lineNumber}`)
+    const output = typeof state.output === "string" ? state.output : null
+    const tool = {
+      line: lineNumber, message, name: part.tool, status: state.status,
+      input: state.input, outputBytes: output === null ? null : Buffer.byteLength(output),
+      truncated: state.metadata?.truncated === true || state.metadata?.display?.truncated === true,
+    }
+    // ponytail: shell parsing is deliberately heuristic; review these candidates before phase attribution.
+    tool.buildCandidate = part.tool === "bash" && /(?:^|[;&|\n])\s*(?:npm\s+run\s+build|(?:npx\s+)?(?:kudzu|vite)\s+build)\b/.test(state.input.command ?? "")
+    if (readTools.has(part.tool) && state.status === "completed" && output !== null && !tool.truncated) {
+      const signature = hash(JSON.stringify([part.tool, canonical(state.input), output]))
+      const previous = observations.get(signature)
+      if (previous) tool.exactRepeat = { line: previous.line, interveningPotentialMutation: previous.epoch !== mutationEpoch }
+      observations.set(signature, { line: lineNumber, epoch: mutationEpoch })
+    } else if (!readTools.has(part.tool) && part.tool !== "todowrite") mutationEpoch++
+    tools.push(tool)
+  }
+  if (!steps.length) throw new Error("No recorded model usage")
+  const firstBuild = tools.find(tool => tool.buildCandidate) ?? null
+  const buildStep = firstBuild ? steps.findIndex(step => step.message === firstBuild.message) : -1
+  const phases = Object.fromEntries(["beforeFirstBuild", "firstBuildMessage", "afterFirstBuild", "unpartitioned"].map(name => [name, { steps: 0, usage: emptyUsage(), legacyNormalizedTokens: 0 }]))
+  for (const [index, step] of steps.entries()) {
+    step.phase = buildStep === -1 ? "unpartitioned" : index < buildStep ? "beforeFirstBuild" : index === buildStep ? "firstBuildMessage" : "afterFirstBuild"
+    const phase = phases[step.phase]
+    phase.steps++
+    for (const key of usageKeys) phase.usage[key] += step.usage[key]
+    // Match the existing adapter, not a new invoice interpretation. Cache writes remain separate.
+    phase.legacyNormalizedTokens += step.usage.input + step.usage.cacheRead + step.usage.output + step.usage.reasoning
+  }
+  const totals = emptyUsage()
+  for (const phase of Object.values(phases)) for (const key of usageKeys) totals[key] += phase.usage[key]
+  const unfinishedMessages = [...new Set([...started, ...tools.map(tool => tool.message)])].filter(message => !seenSteps.has(message))
+  return {
+    sha256: hash(text), sessionID: sessionID ?? null, ignoredLines, errors,
+    recordedSteps: steps.length, unfinishedMessages,
+    terminalStopObserved: steps.at(-1).reason === "stop" && !unfinishedMessages.length && !errors.length,
+    firstBuildCandidate: firstBuild ? { line: firstBuild.line, message: firstBuild.message, command: firstBuild.input.command } : null,
+    phases, usage: totals,
+    legacyNormalizedTokens: Object.values(phases).reduce((sum, phase) => sum + phase.legacyNormalizedTokens, 0),
+    toolCalls: tools.length,
+    recordedToolOutputBytes: tools.reduce((sum, tool) => sum + (tool.outputBytes ?? 0), 0),
+    missingOutputLines: tools.filter(tool => tool.outputBytes === null).map(tool => tool.line),
+    truncatedOutputLines: tools.filter(tool => tool.truncated).map(tool => tool.line),
+    exactRepeatedObservations: tools.filter(tool => tool.exactRepeat).map(tool => ({ line: tool.line, name: tool.name, input: tool.input, outputBytes: tool.outputBytes, previousLine: tool.exactRepeat.line, interveningPotentialMutation: tool.exactRepeat.interveningPotentialMutation })),
+    tools, steps,
+  }
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value && typeof value === "object") return Object.fromEntries(Object.keys(value).sort().map(key => [key, canonical(value[key])]))
+  return value
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const { values, positionals } = parseArgs({ options: { out: { type: "string" }, details: { type: "boolean" } }, allowPositionals: true, strict: true })
+  if (!positionals.length) throw new Error("Use: node test/ai-harness-audit.mjs [--details] [--out report.json] <adapter.stdout> ...")
+  const reports = []
+  for (const file of positionals) {
+    try {
+      const report = auditTrace(await readFile(file, "utf8"))
+      if (!values.details) { delete report.tools; delete report.steps }
+      reports.push({ file: resolve(file), status: "audited", ...report })
+    } catch (error) {
+      reports.push({ file: resolve(file), status: "invalid", error: error.message })
+    }
+  }
+  const complete = reports.every(report => report.status === "audited")
+  const report = JSON.stringify({ schema: 1, complete, caveat: "Read-only recorded-event audit. Build boundaries are heuristic; steps are not per-command costs. Exact repeats are review candidates, not safe cache hits or token savings. Output bytes exclude metadata and are not guaranteed model-visible context. Terminal stop does not establish task acceptance or complete billing.", reports }, null, 2) + "\n"
+  if (values.out) await writeFile(values.out, report, { flag: "wx" })
+  else process.stdout.write(report)
+  if (!complete) process.exitCode = 1
+}

--- a/test/ai-harness-audit.test.mjs
+++ b/test/ai-harness-audit.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { spawnSync } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { auditTrace } from "./ai-harness-audit.mjs"
+
+test("audits recorded usage and conservative repeat candidates without conflating bytes and cost", () => {
+  const tool = (message, name, input, output, metadata = {}) => ({ type: "tool_use", sessionID: "session", part: { messageID: message, tool: name, state: { status: "completed", input, output, metadata } } })
+  const finish = (message, reason = "tool-calls") => ({ type: "step_finish", sessionID: "session", part: { messageID: message, reason, tokens: { input: 10, output: 3, reasoning: 2, cache: { read: 20, write: 4 } } } })
+  const events = [
+    tool("a", "read", { filePath: "a.ts", limit: 10 }, "한글"),
+    tool("a", "read", { limit: 10, filePath: "a.ts" }, "한글"),
+    tool("a", "read", { filePath: "a.ts", offset: 11 }, "한글"),
+    tool("a", "read", { filePath: "a.ts", limit: 10 }, "changed"),
+    tool("a", "read", { filePath: "a.ts", limit: 10 }, "한글", { truncated: true }),
+    finish("a"),
+    tool("b", "bash", { command: "npm run build" }, "failed build"),
+    finish("b"),
+    tool("c", "read", { filePath: "a.ts", limit: 10 }, "한글"),
+    tool("c", "bash", { command: "npm run build" }, "passed build"),
+    finish("c", "stop"),
+  ]
+  const text = "npm installation preamble\n" + events.map(JSON.stringify).join("\n")
+  const report = auditTrace(text)
+  assert.equal(report.legacyNormalizedTokens, 105)
+  assert.deepEqual(report.usage, { input: 30, cacheRead: 60, cacheWrite: 12, output: 9, reasoning: 6 })
+  assert.deepEqual(Object.values(report.phases).map(phase => phase.legacyNormalizedTokens), [35, 35, 35, 0])
+  assert.equal(report.firstBuildCandidate.line, 8)
+  assert.equal(report.tools[0].outputBytes, 6)
+  assert.deepEqual(report.ignoredLines, [1])
+  assert.deepEqual(report.truncatedOutputLines, [6])
+  assert.equal(report.exactRepeatedObservations.length, 2)
+  assert.equal(report.exactRepeatedObservations[0].previousLine, 2)
+  assert.equal(report.exactRepeatedObservations[0].interveningPotentialMutation, false)
+  assert.equal(report.exactRepeatedObservations[1].interveningPotentialMutation, true)
+  assert.equal(report.terminalStopObserved, true)
+  assert.equal(auditTrace(events.slice(0, 6).map(JSON.stringify).join("\n")).phases.unpartitioned.legacyNormalizedTokens, 35)
+  const interrupted = auditTrace(text + "\n" + JSON.stringify({ type: "step_start", part: { messageID: "d" } }))
+  assert.equal(interrupted.terminalStopObserved, false)
+  assert.deepEqual(interrupted.unfinishedMessages, ["d"])
+  assert.throws(() => auditTrace(text + '\n{"broken":'), /Invalid JSON/)
+  assert.throws(() => auditTrace("preamble only"), /No recorded model usage/)
+  assert.throws(() => auditTrace(text + "\n" + JSON.stringify(finish("c"))), /duplicate/)
+  const invalid = finish("z")
+  invalid.part.tokens.input = -1
+  assert.throws(() => auditTrace(JSON.stringify(invalid)), /Invalid usage/)
+  const mixed = finish("z")
+  mixed.sessionID = "another"
+  assert.throws(() => auditTrace(text + "\n" + JSON.stringify(mixed)), /Mixed sessions/)
+})
+
+test("CLI retains missing usage as invalid and refuses to overwrite an earlier report", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "kudzu-harness-audit-"))
+  try {
+    const stream = join(directory, "adapter.stdout"), out = join(directory, "audit.json")
+    await writeFile(stream, "npm installation only\n")
+    const args = [fileURLToPath(new URL("./ai-harness-audit.mjs", import.meta.url)), "--out", out, stream]
+    const result = spawnSync(process.execPath, args, { encoding: "utf8" })
+    assert.equal(result.status, 1)
+    const original = await readFile(out, "utf8"), report = JSON.parse(original)
+    assert.equal(report.complete, false)
+    assert.equal(report.reports[0].status, "invalid")
+    assert.equal(report.reports[0].error, "No recorded model usage")
+    assert.equal(await readFile(stream, "utf8"), "npm installation only\n")
+    assert.equal(spawnSync(process.execPath, args).status, 1)
+    assert.equal(await readFile(out, "utf8"), original)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/test/create-kudzu-ai.test.mjs
+++ b/test/create-kudzu-ai.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile, copyFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+import { docs, check } from "../packages/create-kudzu/ai.mjs"
+
+test("reads installed README sections without including fenced headings or hiding truncation", async t => {
+  const root = await mkdtemp(join(tmpdir(), "kudzu-ai-docs-"))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  const directory = join(root, "node_modules/@kudzujs/core")
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, "package.json"), JSON.stringify({ version: "0.16.30" }))
+  const text = "# Kudzu\n\n## Authoring\nUse state.\n```md\n## Not a section\n```\n## C#\n" + "x".repeat(7000) + "\n## Verify ##\nCheck behavior.\n"
+  await writeFile(join(directory, "README.md"), text)
+  assert.deepEqual((await docs(root)).headings, ["Authoring", "C#", "Verify"])
+  const authoring = await docs(root, "authoring")
+  assert.equal(authoring.version, "0.16.30")
+  assert.equal(authoring.startLine, 3)
+  assert.equal(authoring.endLine, 7)
+  assert.match(authoring.text, /Not a section/)
+  assert.doesNotMatch(authoring.text, /Check behavior/)
+  assert.equal(authoring.truncated, false)
+  const large = await docs(root, "C#")
+  assert.equal(large.text.length, 6000)
+  assert.equal(large.truncated, true)
+  await assert.rejects(docs(root, "../../package.json"), /exact README heading/)
+  assert.equal(await readFile(join(directory, "README.md"), "utf8"), text)
+})
+
+test("executes the real check, retains complete logs, propagates failure, and bounds execution", { timeout: 20000 }, async t => {
+  const root = await mkdtemp(join(tmpdir(), "kudzu-ai-check-"))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  await copyFile(new URL("../packages/create-kudzu/ai.mjs", import.meta.url), join(root, "kudzu-ai.mjs"))
+  await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module", scripts: { check: "node check.mjs" } }))
+  await writeFile(join(root, "check.mjs"), 'console.log("start"); console.log("x".repeat(8000)); console.error("ERROR_IN_FULL_LOG"); console.log("y".repeat(8000)); process.exit(7)\n')
+  const failed = await check(root, 10000)
+  assert.equal(failed.passed, false)
+  assert.equal(failed.exitCode, 7)
+  assert.equal(failed.browserVerified, false)
+  assert.equal(failed.log.truncated, true)
+  assert.ok(failed.log.excerpt.length < 4300)
+  const full = await readFile(failed.log.path)
+  assert.equal(full.length, failed.log.bytes)
+  assert.match(full.toString(), /ERROR_IN_FULL_LOG/)
+  assert.doesNotMatch(failed.log.excerpt, /ERROR_IN_FULL_LOG/)
+  const cli = spawnSync(process.execPath, [join(root, "kudzu-ai.mjs"), "check"], { cwd: tmpdir(), encoding: "utf8", timeout: 10000 })
+  assert.equal(cli.status, 7)
+  assert.equal(JSON.parse(cli.stdout).passed, false)
+  await writeFile(join(root, "check.mjs"), 'console.log("passed")\n')
+  const passed = await check(root, 10000)
+  assert.equal(passed.passed, true)
+  assert.equal(passed.log.truncated, false)
+  assert.notEqual(passed.log.path, failed.log.path)
+  assert.deepEqual(await readFile(failed.log.path), full)
+  await writeFile(join(root, "check.mjs"), 'import { spawn } from "node:child_process"; import { writeFileSync } from "node:fs"; const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]); writeFileSync("child.pid", String(child.pid)); setInterval(() => {}, 1000)\n')
+  const timeout = await check(root, 3000)
+  assert.equal(timeout.passed, false)
+  assert.equal(timeout.timedOut, true)
+  if (process.platform !== "win32") {
+    const pid = Number(await readFile(join(root, "child.pid"), "utf8"))
+    // Killed children can briefly remain zombies; ps status distinguishes them from a live worker.
+    const status = spawnSync("ps", ["-p", String(pid), "-o", "stat="], { encoding: "utf8" })
+    assert.ok(status.status !== 0 || !status.stdout.trim() || status.stdout.trim().startsWith("Z"), status.stdout)
+  }
+  await assert.rejects(check(root, 0), /timeout-ms/)
+  await writeFile(join(root, "check.mjs"), 'import { check } from "./kudzu-ai.mjs"; await check(process.cwd())\n')
+  const recursive = await check(root, 10000)
+  assert.equal(recursive.passed, false)
+  assert.match((await readFile(recursive.log.path)).toString(), /recursively/)
+})

--- a/test/create-kudzu-smoke.mjs
+++ b/test/create-kudzu-smoke.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+
+const root = fileURLToPath(new URL("..", import.meta.url))
+const temporary = await mkdtemp(join(tmpdir(), "kudzu-generator-smoke-"))
+try {
+  const [pack] = JSON.parse(execFileSync("npm", ["pack", "--ignore-scripts", "--json", "--pack-destination", temporary], { cwd: join(root, "packages/create-kudzu"), encoding: "utf8" }))
+  execFileSync("tar", ["-xzf", join(temporary, pack.filename), "-C", temporary])
+  assert.ok(pack.files.some(file => file.path === "ai.mjs"))
+  const version = JSON.parse(await readFile(join(root, "package.json"), "utf8")).version
+  const results = []
+  let guidanceBytes
+  for (const mode of ["baseline", "guided"]) {
+    const parent = join(temporary, mode)
+    await mkdir(parent)
+    execFileSync(process.execPath, [join(temporary, "package/index.mjs"), "app", "--no-install", ...(mode === "guided" ? ["--ai"] : [])], { cwd: parent })
+    const app = join(parent, "app")
+    // Use identical installed core/TypeScript for both arms; no registry version drift.
+    await mkdir(join(app, "node_modules/@kudzujs"), { recursive: true })
+    await symlink(root, join(app, "node_modules/@kudzujs/core"), "dir")
+    await symlink(join(root, "node_modules/typescript"), join(app, "node_modules/typescript"), "dir")
+    await mkdir(join(app, "node_modules/.bin"))
+    await symlink(join(root, "node_modules/typescript/bin/tsc"), join(app, "node_modules/.bin/tsc"))
+    await symlink(join(root, "bin/kudzu.mjs"), join(app, "node_modules/.bin/kudzu"))
+    if (mode === "guided") {
+      const doc = JSON.parse(execFileSync(process.execPath, [join(app, "kudzu-ai.mjs"), "docs", "Authoring"], { encoding: "utf8" }))
+      assert.equal(doc.version, version)
+      assert.match(doc.text, /event.currentTarget/)
+      const checked = JSON.parse(execFileSync("npm", ["run", "--silent", "ai", "--", "check"], { cwd: app, encoding: "utf8" }))
+      assert.equal(checked.passed, true)
+      assert.equal(checked.browserVerified, false)
+      assert.match(await readFile(checked.log.path, "utf8"), /Built 2 page/)
+      guidanceBytes = (await readFile(join(app, "AGENTS.md"))).length
+    } else execFileSync("npm", ["run", "check"], { cwd: app, stdio: "inherit" })
+    const dist = join(app, "dist"), outputs = {}
+    for (const entry of await readdir(dist, { recursive: true, withFileTypes: true })) {
+      if (!entry.isFile()) continue
+      const file = join(entry.parentPath, entry.name)
+      outputs[relative(dist, file)] = await readFile(file)
+    }
+    assert.ok(!Object.keys(outputs).some(path => /AGENTS|README|kudzu-ai|\.kudzu-ai/.test(path)))
+    assert.doesNotMatch(outputs["about/index.html"].toString(), /<script|modulepreload/)
+    results.push(outputs)
+  }
+  assert.deepEqual(results[1], results[0])
+  console.log(JSON.stringify({ core: version, generatorFiles: pack.files.length, guidanceBytes, identicalDeployFiles: Object.keys(results[0]).length, deployRawBytes: Object.values(results[0]).reduce((sum, value) => sum + value.length, 0), deployAggregateGzipBytes: Object.values(results[0]).reduce((sum, value) => sum + gzipSync(value).length, 0), tokenSavings: "unmeasured" }))
+} finally {
+  await rm(temporary, { recursive: true, force: true })
+}

--- a/test/create-kudzu.test.mjs
+++ b/test/create-kudzu.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { spawnSync } from "node:child_process"
@@ -27,7 +27,7 @@ test("creates a Kudzu project", async t => {
   const readme = await readFile(join(directory, "app/README.md"), "utf8")
   const generatorPackage = JSON.parse(await readFile(new URL("../packages/create-kudzu/package.json", import.meta.url), "utf8"))
   const generatorLock = JSON.parse(await readFile(new URL("../packages/create-kudzu/package-lock.json", import.meta.url), "utf8"))
-  assert.equal(packageJson.dependencies["@kudzujs/core"], "^0.16.30")
+  assert.equal(packageJson.dependencies["@kudzujs/core"], "^0.16.34")
   assert.deepEqual(tsconfig.compilerOptions.types, [])
   assert.equal(packageJson.devDependencies.typescript, "^5.9.2")
   assert.equal(packageJson.scripts.check, "tsc --noEmit && kudzu build")
@@ -42,4 +42,44 @@ test("creates a Kudzu project", async t => {
   assert.match(readme, /npm install\s+npm run dev/)
   assert.equal(generatorLock.version, generatorPackage.version)
   assert.equal(generatorLock.packages[""].version, generatorPackage.version)
+  await assert.rejects(readFile(join(directory, "app/AGENTS.md")), { code: "ENOENT" })
+})
+
+test("opts into bounded app guidance without changing generated application code", async t => {
+  const directory = await mkdtemp(join(tmpdir(), "create-kudzu-ai-"))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const generator = fileURLToPath(new URL("../packages/create-kudzu/index.mjs", import.meta.url))
+  for (const mode of ["baseline", "guided"]) {
+    const cwd = join(directory, mode)
+    await mkdir(cwd)
+    const result = spawnSync(process.execPath, [generator, "app", "--no-install", ...(mode === "guided" ? ["--ai"] : [])], { cwd, encoding: "utf8" })
+    assert.equal(result.status, 0, result.stderr)
+    if (mode === "guided") assert.match(result.stdout, /AGENTS\.md/)
+  }
+  const baseline = join(directory, "baseline/app"), guided = join(directory, "guided/app")
+  const before = await readdir(baseline, { recursive: true }), after = await readdir(guided, { recursive: true })
+  assert.deepEqual(after.toSorted(), [...before, "AGENTS.md", "kudzu-ai.mjs"].toSorted())
+  for (const file of await readdir(baseline, { recursive: true, withFileTypes: true })) {
+    if (!file.isFile() || ["README.md", "package.json", ".gitignore"].includes(file.name)) continue
+    const path = join(file.parentPath, file.name)
+    assert.deepEqual(await readFile(path), await readFile(path.replace(baseline, guided)))
+  }
+  const originalManifest = JSON.parse(await readFile(join(baseline, "package.json"), "utf8"))
+  const guidedManifest = JSON.parse(await readFile(join(guided, "package.json"), "utf8"))
+  assert.equal(guidedManifest.scripts.ai, "node kudzu-ai.mjs")
+  delete guidedManifest.scripts.ai
+  assert.deepEqual(guidedManifest, originalManifest)
+  assert.equal(await readFile(join(guided, ".gitignore"), "utf8"), await readFile(join(baseline, ".gitignore"), "utf8") + ".kudzu-ai/\n")
+  assert.deepEqual(await readFile(join(guided, "kudzu-ai.mjs")), await readFile(new URL("../packages/create-kudzu/ai.mjs", import.meta.url)))
+  const guidance = await readFile(join(guided, "AGENTS.md"), "utf8")
+  assert.ok(Buffer.byteLength(guidance) <= 2048, "default AI context must stay within 2 KiB")
+  assert.match(guidance, /node_modules\/@kudzujs\/core\/README\.md/)
+  assert.match(guidance, /npm run check/)
+  assert.match(guidance, /browser/)
+  assert.match(await readFile(join(guided, "README.md"), "utf8"), /AGENTS\.md/)
+  await writeFile(join(guided, "AGENTS.md"), "User-owned instructions\n")
+  const rejected = spawnSync(process.execPath, [generator, guided, "--ai", "--no-install"], { encoding: "utf8" })
+  assert.notEqual(rejected.status, 0)
+  assert.match(rejected.stderr, /not empty/)
+  assert.equal(await readFile(join(guided, "AGENTS.md"), "utf8"), "User-owned instructions\n")
 })


### PR DESCRIPTION
## Summary

Release core **0.16.34** and **create-kudzu 0.1.156**, based on public 0.16.33.

- `create-kudzu --ai` generates app instructions, a dependency-free `kudzu-ai.mjs`, an `ai` npm script, and ignored logs.
- `npm run ai -- docs [heading]` reads installed-version documentation with explicit section bounds.
- `npm run ai -- check` executes the existing typecheck/build, retains full logs, bounds excerpts, propagates failures and terminates timed-out process groups.
- Adds a read-only trace auditor and retains the provenance/limitations of the historical R2 audit.
- Adds packed-generator deployment parity checks to the existing package-smoke gate.
- Updates release metadata and documentation; compiler/runtime sources are unchanged from 0.16.33. Other-session uncommitted work is excluded.

## What was actually measured?

**No end-to-end AI-token or monetary reduction has been measured.** This PR does not claim a percentage saving or clear the AI-delivery/1.0 gates.

| Evidence | Result |
|---|---|
| Generated instructions | 1,828 UTF-8 bytes (tested ceiling: 2 KiB) |
| Selected document text | Capped at 6,000 characters; source ranges retained |
| Check-log excerpt | First/last 2,048 bytes when truncated; complete log preserved |
| Normal versus AI starter deployment | Four byte-identical files; 9,758 raw / 3,746 aggregate gzip bytes in each arm |
| Additional browser bytes | 0 in the tested default starter |
| Historical audit | 49 R2 usage streams reconciled; one missing-usage stream remains incomplete |

These are output/accounting checks, not token savings. R16 raw logs and a separately approved same-framework model experiment are still needed for the cost claim.

## Validation

- [x] Focused generator/harness/auditor tests: 6/6
- [x] `npm run check`: 230 pages
- [x] `npm run test:package`: fresh core package smoke and paired packed-generator smoke
- [x] `git diff --check`
- [x] Exact PR CI: Linux Node 22 and Node 24/required Chrome. Node 24 passes standalone 1/1 plus 336/336, zero skips.

CI receipt: https://github.com/kudzujs/kudzu/actions/runs/34694197104/attempts/2 . The initial existing autosave browser assertion failure is retained in attempt 1 and the PR comment; the failed job passed one unchanged rerun. No assertions or budgets were relaxed.

After green PR checks, merge using the requested release commit subject. Wait for merged-commit CI before the immutable `v0.16.34` tag and GitHub release. Existing protected npm-environment approval remains in effect.
